### PR TITLE
Add Serilog logging to application layers

### DIFF
--- a/src/Api/Controllers/AuthController.cs
+++ b/src/Api/Controllers/AuthController.cs
@@ -3,6 +3,7 @@ using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace AirlineBooking.Api.Controllers;
 
@@ -11,22 +12,28 @@ namespace AirlineBooking.Api.Controllers;
 public class AuthController : ControllerBase
 {
     private readonly IConfiguration _config;
+    private readonly ILogger<AuthController> _logger;
 
-    public AuthController(IConfiguration config)
+    public AuthController(IConfiguration config, ILogger<AuthController> logger)
     {
         _config = config;
+        _logger = logger;
     }
 
     [HttpPost("login")]
     public IActionResult Login([FromBody] LoginRequest request)
     {
+        _logger.LogInformation("Login attempt for user {Username}", request.Username);
+
         // Simple mock user check
         if (request.Username == "admin" && request.Password == "password")
         {
             var token = GenerateJwtToken(request.Username);
+            _logger.LogInformation("Successful login for user {Username}", request.Username);
             return Ok(new { Token = token });
         }
 
+        _logger.LogWarning("Invalid login attempt for user {Username}", request.Username);
         return Unauthorized();
     }
 

--- a/src/Api/Controllers/BookingsController.cs
+++ b/src/Api/Controllers/BookingsController.cs
@@ -3,6 +3,7 @@ using AirlineBooking.Application.Bookings.Queries;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace AirlineBooking.Api.Controllers;
 
@@ -12,30 +13,50 @@ namespace AirlineBooking.Api.Controllers;
 public class BookingsController : ControllerBase
 {
     private readonly IMediator _mediator;
+    private readonly ILogger<BookingsController> _logger;
 
-    public BookingsController(IMediator mediator)
+    public BookingsController(IMediator mediator, ILogger<BookingsController> logger)
     {
         _mediator = mediator;
+        _logger = logger;
     }
 
     [HttpPost]
     public async Task<IActionResult> CreateBooking([FromBody] CreateBookingCommand command)
     {
+        _logger.LogInformation("Received booking creation request for flight {FlightId} with {Seats} seats", command.FlightId, command.Seats);
         var result = await _mediator.Send(command);
+        _logger.LogInformation("Booking created with PNR {Pnr} and BookingId {BookingId}", result.Pnr, result.BookingId);
         return Ok(result);
     }
 
     [HttpPost("confirm/{pnr}")]
     public async Task<IActionResult> ConfirmBooking(string pnr)
     {
+        _logger.LogInformation("Received booking confirmation request for PNR {Pnr}", pnr);
         var success = await _mediator.Send(new ConfirmBookingCommand(pnr));
-        return success ? NoContent() : NotFound();
+        if (success)
+        {
+            _logger.LogInformation("Booking with PNR {Pnr} confirmed", pnr);
+            return NoContent();
+        }
+
+        _logger.LogWarning("Booking with PNR {Pnr} could not be confirmed", pnr);
+        return NotFound();
     }
 
     [HttpGet("{pnr}")]
     public async Task<IActionResult> GetBooking(string pnr)
     {
+        _logger.LogInformation("Retrieving booking details for PNR {Pnr}", pnr);
         var result = await _mediator.Send(new GetBookingByPnrQuery(pnr));
-        return result is null ? NotFound() : Ok(result);
+        if (result is null)
+        {
+            _logger.LogWarning("Booking with PNR {Pnr} was not found", pnr);
+            return NotFound();
+        }
+
+        _logger.LogInformation("Booking with PNR {Pnr} retrieved successfully", pnr);
+        return Ok(result);
     }
 }

--- a/src/Api/Controllers/FlightsController.cs
+++ b/src/Api/Controllers/FlightsController.cs
@@ -4,6 +4,7 @@ using AirlineBooking.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace AirlineBooking.Api.Controllers;
 
@@ -12,37 +13,53 @@ namespace AirlineBooking.Api.Controllers;
 public class FlightsController : ControllerBase
 {
     private readonly IMediator _mediator;
+    private readonly ILogger<FlightsController> _logger;
 
-    public FlightsController(IMediator mediator)
+    public FlightsController(IMediator mediator, ILogger<FlightsController> logger)
     {
         _mediator = mediator;
+        _logger = logger;
     }
 
     [HttpGet("search")]
     public async Task<IActionResult> SearchFlights([FromQuery] string from, [FromQuery] string to, [FromQuery] DateTime date)
     {
+        _logger.LogInformation("Searching flights from {From} to {To} on {Date}", from, to, date);
         var result = await _mediator.Send(new SearchFlightsQuery(from, to, date));
+        _logger.LogInformation("Found {Count} flights from {From} to {To} on {Date}", result.Count, from, to, date);
         return Ok(result);
     }
 
     [HttpPost]
     public async Task<IActionResult> CreateFlight([FromBody] CreateFlightCommand command)
     {
+        _logger.LogInformation("Creating flight {FlightNumber} from {From} to {To} on {DepartureUtc}", command.FlightNumber, command.FromAirport, command.ToAirport, command.DepartureUtc);
         var id = await _mediator.Send(command);
+        _logger.LogInformation("Flight {FlightNumber} created with Id {FlightId}", command.FlightNumber, id);
         return CreatedAtAction(nameof(GetFlightById), new { id }, null);
     }
 
     [HttpGet("{id}")]
     public async Task<IActionResult> GetFlightById([FromServices] AppDbContext db, Guid id)
     {
+        _logger.LogInformation("Retrieving flight with Id {FlightId}", id);
         var flight = await db.Flights.FindAsync(id);
-        return flight is null ? NotFound() : Ok(flight);
+        if (flight is null)
+        {
+            _logger.LogWarning("Flight with Id {FlightId} not found", id);
+            return NotFound();
+        }
+
+        _logger.LogInformation("Flight with Id {FlightId} retrieved successfully", id);
+        return Ok(flight);
     }
 
     [HttpGet]
     public async Task<IActionResult> GetAllFlights([FromServices] AppDbContext db)
     {
+        _logger.LogInformation("Retrieving all flights");
         var flights = await db.Flights.ToListAsync();
+        _logger.LogInformation("Retrieved {Count} flights", flights.Count);
         return Ok(flights);
     }
 }

--- a/src/Application/Bookings/Commands/ConfirmBookingHandler.cs
+++ b/src/Application/Bookings/Commands/ConfirmBookingHandler.cs
@@ -1,5 +1,6 @@
 using AirlineBooking.Application.Common.Interfaces;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,8 +9,29 @@ namespace AirlineBooking.Application.Bookings.Commands;
 public sealed class ConfirmBookingHandler : IRequestHandler<ConfirmBookingCommand, bool>
 {
     private readonly IBookingService _svc;
-    public ConfirmBookingHandler(IBookingService svc) => _svc = svc;
+    private readonly ILogger<ConfirmBookingHandler> _logger;
+    public ConfirmBookingHandler(IBookingService svc, ILogger<ConfirmBookingHandler> logger)
+    {
+        _svc = svc;
+        _logger = logger;
+    }
 
     public Task<bool> Handle(ConfirmBookingCommand request, CancellationToken ct)
-        => _svc.ConfirmBookingAsync(request.Pnr, ct);
+        => HandleInternalAsync(request, ct);
+
+    private async Task<bool> HandleInternalAsync(ConfirmBookingCommand request, CancellationToken ct)
+    {
+        _logger.LogInformation("Handling ConfirmBookingCommand for PNR {Pnr}", request.Pnr);
+        var success = await _svc.ConfirmBookingAsync(request.Pnr, ct);
+        if (success)
+        {
+            _logger.LogInformation("Booking with PNR {Pnr} confirmed successfully", request.Pnr);
+        }
+        else
+        {
+            _logger.LogWarning("Booking with PNR {Pnr} could not be confirmed", request.Pnr);
+        }
+
+        return success;
+    }
 }

--- a/src/Application/Bookings/Commands/CreateBookingHandler.cs
+++ b/src/Application/Bookings/Commands/CreateBookingHandler.cs
@@ -1,5 +1,6 @@
 using AirlineBooking.Application.Common.Interfaces;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,8 +9,23 @@ namespace AirlineBooking.Application.Bookings.Commands;
 public sealed class CreateBookingHandler : IRequestHandler<CreateBookingCommand, CreateBookingResult>
 {
     private readonly IBookingService _svc;
-    public CreateBookingHandler(IBookingService svc) => _svc = svc;
+    private readonly ILogger<CreateBookingHandler> _logger;
+    public CreateBookingHandler(IBookingService svc, ILogger<CreateBookingHandler> logger)
+    {
+        _svc = svc;
+        _logger = logger;
+    }
 
     public Task<CreateBookingResult> Handle(CreateBookingCommand request, CancellationToken ct)
-        => _svc.CreateBookingAsync(request, ct);
+    {
+        _logger.LogInformation("Handling CreateBookingCommand for flight {FlightId} with {Seats} seats", request.FlightId, request.Seats);
+        return HandleInternalAsync(request, ct);
+    }
+
+    private async Task<CreateBookingResult> HandleInternalAsync(CreateBookingCommand request, CancellationToken ct)
+    {
+        var result = await _svc.CreateBookingAsync(request, ct);
+        _logger.LogInformation("Booking created with BookingId {BookingId} and PNR {Pnr}", result.BookingId, result.Pnr);
+        return result;
+    }
 }

--- a/src/Application/Bookings/Queries/GetBookingByPnrHandler.cs
+++ b/src/Application/Bookings/Queries/GetBookingByPnrHandler.cs
@@ -1,5 +1,6 @@
 using AirlineBooking.Application.Common.Interfaces;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,8 +9,29 @@ namespace AirlineBooking.Application.Bookings.Queries;
 public sealed class GetBookingByPnrHandler : IRequestHandler<GetBookingByPnrQuery, BookingDto?>
 {
     private readonly IBookingService _svc;
-    public GetBookingByPnrHandler(IBookingService svc) => _svc = svc;
+    private readonly ILogger<GetBookingByPnrHandler> _logger;
+    public GetBookingByPnrHandler(IBookingService svc, ILogger<GetBookingByPnrHandler> logger)
+    {
+        _svc = svc;
+        _logger = logger;
+    }
 
     public Task<BookingDto?> Handle(GetBookingByPnrQuery request, CancellationToken ct)
-        => _svc.GetByPnrAsync(request.Pnr, ct);
+        => HandleInternalAsync(request, ct);
+
+    private async Task<BookingDto?> HandleInternalAsync(GetBookingByPnrQuery request, CancellationToken ct)
+    {
+        _logger.LogInformation("Handling GetBookingByPnrQuery for PNR {Pnr}", request.Pnr);
+        var result = await _svc.GetByPnrAsync(request.Pnr, ct);
+        if (result is null)
+        {
+            _logger.LogWarning("No booking found for PNR {Pnr}", request.Pnr);
+        }
+        else
+        {
+            _logger.LogInformation("Booking found for PNR {Pnr}", request.Pnr);
+        }
+
+        return result;
+    }
 }

--- a/src/Application/Flights/Commands/CreateFlightHandler.cs
+++ b/src/Application/Flights/Commands/CreateFlightHandler.cs
@@ -1,29 +1,31 @@
-﻿using AirlineBooking.Domain.Flights;
-using MediatR;
+﻿using MediatR;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using AirlineBooking.Application.Common.Interfaces;
+using Microsoft.Extensions.Logging;
 
 namespace AirlineBooking.Flights.Commands
 {
     public class CreateFlightCommandHandler : IRequestHandler<CreateFlightCommand, Guid>
     {
         private readonly IFlightCreateService _flightCreateService;
+        private readonly ILogger<CreateFlightCommandHandler> _logger;
 
 
-        public CreateFlightCommandHandler(IFlightCreateService flightService)
+        public CreateFlightCommandHandler(IFlightCreateService flightService, ILogger<CreateFlightCommandHandler> logger)
         {
             _flightCreateService = flightService;
+            _logger = logger;
         }
 
 
         public async Task<Guid> Handle(CreateFlightCommand request, CancellationToken cancellationToken)
         {
-            return await _flightCreateService.CreateFlightAsync(request, cancellationToken);
+            _logger.LogInformation("Handling CreateFlightCommand for flight {FlightNumber}", request.FlightNumber);
+            var id = await _flightCreateService.CreateFlightAsync(request, cancellationToken);
+            _logger.LogInformation("Flight {FlightNumber} created with Id {FlightId}", request.FlightNumber, id);
+            return id;
         }
     }
 }

--- a/src/Application/Flights/Queries/SearchFlightsHandler.cs
+++ b/src/Application/Flights/Queries/SearchFlightsHandler.cs
@@ -1,5 +1,6 @@
 using AirlineBooking.Application.Common.Interfaces;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,8 +10,21 @@ namespace AirlineBooking.Application.Flights.Queries;
 public sealed class SearchFlightsHandler : IRequestHandler<SearchFlightsQuery, IReadOnlyList<FlightDto>>
 {
     private readonly IFlightQueryService _service;
-    public SearchFlightsHandler(IFlightQueryService service) => _service = service;
+    private readonly ILogger<SearchFlightsHandler> _logger;
+    public SearchFlightsHandler(IFlightQueryService service, ILogger<SearchFlightsHandler> logger)
+    {
+        _service = service;
+        _logger = logger;
+    }
 
     public Task<IReadOnlyList<FlightDto>> Handle(SearchFlightsQuery request, CancellationToken ct)
-        => _service.SearchAsync(request.From, request.To, request.Date, ct);
+        => HandleInternalAsync(request, ct);
+
+    private async Task<IReadOnlyList<FlightDto>> HandleInternalAsync(SearchFlightsQuery request, CancellationToken ct)
+    {
+        _logger.LogInformation("Handling SearchFlightsQuery from {From} to {To} on {Date}", request.From, request.To, request.Date);
+        var results = await _service.SearchAsync(request.From, request.To, request.Date, ct);
+        _logger.LogInformation("SearchFlightsQuery returned {Count} flights", results.Count);
+        return results;
+    }
 }

--- a/src/Infrastructure/Services/BookingService.cs
+++ b/src/Infrastructure/Services/BookingService.cs
@@ -5,6 +5,7 @@ using AirlineBooking.Domain.Bookings;
 using AirlineBooking.Domain.Inventory;
 using AirlineBooking.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Threading;
@@ -16,12 +17,20 @@ public sealed class BookingService : IBookingService
 {
     private readonly AppDbContext _db;
     private readonly IIdempotencyStore _idem;
-    public BookingService(AppDbContext db, IIdempotencyStore idem) { _db = db; _idem = idem; }
+    private readonly ILogger<BookingService> _logger;
+    public BookingService(AppDbContext db, IIdempotencyStore idem, ILogger<BookingService> logger)
+    {
+        _db = db;
+        _idem = idem;
+        _logger = logger;
+    }
 
     public async Task<CreateBookingResult> CreateBookingAsync(CreateBookingCommand request, CancellationToken ct)
     {
+        _logger.LogInformation("Creating booking for flight {FlightId} with {Seats} seats", request.FlightId, request.Seats);
         if (await _idem.ExistsAsync(request.IdempotencyKey, ct))
         {
+            _logger.LogInformation("Idempotency key {Key} already processed, returning existing booking", request.IdempotencyKey);
             var recent = await _db.Bookings
                 .OrderByDescending(b => b.CreatedAtUtc)
                 .FirstOrDefaultAsync(b => b.FlightId == request.FlightId && b.Seats == request.Seats, ct);
@@ -29,10 +38,10 @@ public sealed class BookingService : IBookingService
         }
 
         var flight = await _db.Flights.AsTracking().FirstOrDefaultAsync(f => f.Id == request.FlightId, ct)
-            ?? throw new InvalidOperationException("Flight not found");
+            ?? throw LogAndThrow(request.FlightId, "Flight not found");
 
         var inventory = await _db.SeatInventories.AsTracking().FirstOrDefaultAsync(i => i.FlightId == flight.Id, ct)
-            ?? throw new InvalidOperationException("Inventory not found");
+            ?? throw LogAndThrow(flight.Id, "Inventory not found");
 
         var pax = new Passenger(request.FirstName, request.LastName, request.Email);
         _db.Passengers.Add(pax);
@@ -47,26 +56,42 @@ public sealed class BookingService : IBookingService
         await _db.SaveChangesAsync(ct);
         await _idem.MarkAsync(request.IdempotencyKey, ct);
 
+        _logger.LogInformation("Booking created with BookingId {BookingId} and PNR {Pnr}", booking.Id, booking.Pnr);
         return new CreateBookingResult(pnr, booking.Id, amount);
     }
 
     public async Task<bool> ConfirmBookingAsync(string pnr, CancellationToken ct)
     {
+        _logger.LogInformation("Confirming booking with PNR {Pnr}", pnr);
         var booking = await _db.Bookings.FirstOrDefaultAsync(b => b.Pnr == pnr, ct);
-        if (booking is null) return false;
-        if (booking.Status == BookingStatus.Confirmed) return true;
-        if (booking.Status == BookingStatus.Cancelled) return false;
+        if (booking is null)
+        {
+            _logger.LogWarning("Booking with PNR {Pnr} not found", pnr);
+            return false;
+        }
+        if (booking.Status == BookingStatus.Confirmed)
+        {
+            _logger.LogInformation("Booking with PNR {Pnr} already confirmed", pnr);
+            return true;
+        }
+        if (booking.Status == BookingStatus.Cancelled)
+        {
+            _logger.LogWarning("Booking with PNR {Pnr} is cancelled and cannot be confirmed", pnr);
+            return false;
+        }
 
         var inventory = await _db.SeatInventories.FirstAsync(i => i.FlightId == booking.FlightId, ct);
         inventory.Confirm(booking.Seats);
         booking.Confirm();
 
         await _db.SaveChangesAsync(ct);
+        _logger.LogInformation("Booking with PNR {Pnr} confirmed", pnr);
         return true;
     }
 
     public async Task<BookingDto?> GetByPnrAsync(string pnr, CancellationToken ct)
     {
+        _logger.LogInformation("Retrieving booking information for PNR {Pnr}", pnr);
         var dto = await _db.Bookings
             .Where(b => b.Pnr == pnr)
             .Select(b => new BookingDto(
@@ -77,6 +102,15 @@ public sealed class BookingService : IBookingService
                 b.Seats, b.Amount))
             .FirstOrDefaultAsync(ct);
 
+        if (dto is null)
+        {
+            _logger.LogWarning("No booking found for PNR {Pnr}", pnr);
+        }
+        else
+        {
+            _logger.LogInformation("Booking for PNR {Pnr} retrieved successfully", pnr);
+        }
+
         return dto;
     }
 
@@ -85,5 +119,11 @@ public sealed class BookingService : IBookingService
         const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
         var rnd = Random.Shared;
         return new string(Enumerable.Range(0, 6).Select(_ => chars[rnd.Next(chars.Length)]).ToArray());
+    }
+
+    private InvalidOperationException LogAndThrow(Guid flightId, string message)
+    {
+        _logger.LogError("{Message} for flight {FlightId}", message, flightId);
+        return new InvalidOperationException(message);
     }
 }

--- a/src/Infrastructure/Services/FlightCreateService.cs
+++ b/src/Infrastructure/Services/FlightCreateService.cs
@@ -3,39 +3,38 @@ using AirlineBooking.Flights.Commands;
 using AirlineBooking.Infrastructure.Persistence;
 using System;
 using AirlineBooking.Application.Common.Interfaces;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace AirlineBooking.Infrastructure.Services
 {
-
     public class FlightCreateService : IFlightCreateService
     {
         private readonly AppDbContext _context;
+        private readonly ILogger<FlightCreateService> _logger;
 
-
-        public FlightCreateService(AppDbContext context)
+        public FlightCreateService(AppDbContext context, ILogger<FlightCreateService> logger)
         {
             _context = context;
+            _logger = logger;
         }
-
 
         public async Task<Guid> CreateFlightAsync(CreateFlightCommand command, CancellationToken cancellationToken)
         {
+            _logger.LogInformation("Persisting new flight {FlightNumber} from {From} to {To}", command.FlightNumber, command.FromAirport, command.ToAirport);
             var flight = new Flight(
-            command.FlightNumber,
-            command.FromAirport,
-            command.ToAirport,
-            command.DepartureUtc,
-            command.ArrivalUtc,
-            command.Capacity,
-            command.BaseFare);
-
+                command.FlightNumber,
+                command.FromAirport,
+                command.ToAirport,
+                command.DepartureUtc,
+                command.ArrivalUtc,
+                command.Capacity,
+                command.BaseFare);
 
             _context.Flights.Add(flight);
             await _context.SaveChangesAsync(cancellationToken);
+            _logger.LogInformation("Flight {FlightNumber} persisted with Id {FlightId}", flight.FlightNumber, flight.Id);
             return flight.Id;
         }
     }

--- a/src/Infrastructure/Services/FlightQueryService..cs
+++ b/src/Infrastructure/Services/FlightQueryService..cs
@@ -1,7 +1,8 @@
-﻿using AirlineBooking.Application.Common.Interfaces;
+using AirlineBooking.Application.Common.Interfaces;
 using AirlineBooking.Application.Flights.Queries;
 using AirlineBooking.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,17 +14,24 @@ namespace AirlineBooking.Infrastructure.Services;
 public sealed class FlightQueryService : IFlightQueryService
 {
     private readonly AppDbContext _db;
-    public FlightQueryService(AppDbContext db) => _db = db;
+    private readonly ILogger<FlightQueryService> _logger;
+
+    public FlightQueryService(AppDbContext db, ILogger<FlightQueryService> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
 
     public async Task<IReadOnlyList<FlightDto>> SearchAsync(string from, string to, DateTime date, CancellationToken ct)
     {
+        _logger.LogInformation("Searching flights in persistence from {From} to {To} on {Date}", from, to, date);
         var dateStart = new DateTimeOffset(date, TimeSpan.Zero);
         var dateEnd = dateStart.AddDays(1);
-        
+
         var fromUpper = from.Trim().ToUpperInvariant();
         var toUpper = to.Trim().ToUpperInvariant();
-        
-        return await _db.Flights
+
+        var results = await _db.Flights
             .Where(f => f.FromAirport == fromUpper
                         && f.ToAirport == toUpper
                         && f.DepartureUtc >= dateStart
@@ -38,6 +46,7 @@ public sealed class FlightQueryService : IFlightQueryService
                 f.BaseFare))
             .ToListAsync(ct);
 
-       
+        _logger.LogInformation("Flight search returned {Count} records", results.Count);
+        return results;
     }
 }

--- a/src/Infrastructure/Services/IdempotencyStore.cs
+++ b/src/Infrastructure/Services/IdempotencyStore.cs
@@ -1,6 +1,7 @@
 using AirlineBooking.Application.Common.Interfaces;
 using AirlineBooking.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,15 +10,31 @@ namespace AirlineBooking.Infrastructure.Services;
 public sealed class IdempotencyStore : IIdempotencyStore
 {
     private readonly AppDbContext _db;
-    public IdempotencyStore(AppDbContext db) => _db = db;
+    private readonly ILogger<IdempotencyStore> _logger;
+
+    public IdempotencyStore(AppDbContext db, ILogger<IdempotencyStore> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
 
     public async Task<bool> ExistsAsync(string key, CancellationToken ct)
-        => await _db.IdempotencyRecords.AnyAsync(x => x.Key == key, ct);
+    {
+        var exists = await _db.IdempotencyRecords.AnyAsync(x => x.Key == key, ct);
+        _logger.LogInformation("Checked idempotency key {Key}. Exists: {Exists}", key, exists);
+        return exists;
+    }
 
     public async Task MarkAsync(string key, CancellationToken ct)
     {
-        if (await ExistsAsync(key, ct)) return;
+        if (await ExistsAsync(key, ct))
+        {
+            _logger.LogInformation("Idempotency key {Key} already marked", key);
+            return;
+        }
+
         _db.IdempotencyRecords.Add(new IdempotencyRecord { Key = key });
         await _db.SaveChangesAsync(ct);
+        _logger.LogInformation("Marked idempotency key {Key}", key);
     }
 }


### PR DESCRIPTION
## Summary
- add structured Serilog-powered logging to the API controllers for authentication, bookings, and flights
- instrument booking and flight MediatR handlers with contextual logging
- extend infrastructure services with detailed logging around persistence, idempotency, and booking confirmation flows

## Testing
- dotnet test *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9bebae64c8329ac58a7373d79041a