### PR TITLE
Add validation across API and application contracts

### DIFF
--- a/src/Api/Controllers/BookingsController.cs
+++ b/src/Api/Controllers/BookingsController.cs
@@ -1,9 +1,10 @@
-﻿using AirlineBooking.Application.Bookings.Commands;
+using AirlineBooking.Application.Bookings.Commands;
 using AirlineBooking.Application.Bookings.Queries;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using System.ComponentModel.DataAnnotations;
 
 namespace AirlineBooking.Api.Controllers;
 
@@ -24,6 +25,11 @@ public class BookingsController : ControllerBase
     [HttpPost]
     public async Task<IActionResult> CreateBooking([FromBody] CreateBookingCommand command)
     {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
         _logger.LogInformation("Received booking creation request for flight {FlightId} with {Seats} seats", command.FlightId, command.Seats);
         var result = await _mediator.Send(command);
         _logger.LogInformation("Booking created with PNR {Pnr} and BookingId {BookingId}", result.Pnr, result.BookingId);
@@ -31,8 +37,13 @@ public class BookingsController : ControllerBase
     }
 
     [HttpPost("confirm/{pnr}")]
-    public async Task<IActionResult> ConfirmBooking(string pnr)
+    public async Task<IActionResult> ConfirmBooking([FromRoute][Required][RegularExpression("^[A-Z0-9]{6}$")] string pnr)
     {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
         _logger.LogInformation("Received booking confirmation request for PNR {Pnr}", pnr);
         var success = await _mediator.Send(new ConfirmBookingCommand(pnr));
         if (success)
@@ -46,8 +57,13 @@ public class BookingsController : ControllerBase
     }
 
     [HttpGet("{pnr}")]
-    public async Task<IActionResult> GetBooking(string pnr)
+    public async Task<IActionResult> GetBooking([FromRoute][Required][RegularExpression("^[A-Z0-9]{6}$")] string pnr)
     {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
         _logger.LogInformation("Retrieving booking details for PNR {Pnr}", pnr);
         var result = await _mediator.Send(new GetBookingByPnrQuery(pnr));
         if (result is null)

--- a/src/Application/Bookings/Commands/ConfirmBooking.cs
+++ b/src/Application/Bookings/Commands/ConfirmBooking.cs
@@ -1,5 +1,32 @@
 using MediatR;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 
 namespace AirlineBooking.Application.Bookings.Commands;
 
-public sealed record ConfirmBookingCommand(string Pnr) : IRequest<bool>;
+public sealed record ConfirmBookingCommand(
+    [Required]
+    [RegularExpression("^[A-Z0-9]{6}$", ErrorMessage = "PNR must be exactly 6 alphanumeric characters.")]
+    string Pnr
+) : IRequest<bool>, IValidatableObject
+{
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.IsNullOrWhiteSpace(Pnr))
+        {
+            yield return new ValidationResult("PNR cannot be empty.", new[] { nameof(Pnr) });
+            yield break;
+        }
+
+        if (Pnr.Length != 6)
+        {
+            yield return new ValidationResult("PNR must contain exactly six characters.", new[] { nameof(Pnr) });
+        }
+
+        if (Pnr.Length == 6 && Pnr.Any(ch => !char.IsLetterOrDigit(ch)))
+        {
+            yield return new ValidationResult("PNR must contain only letters and digits.", new[] { nameof(Pnr) });
+        }
+    }
+}

--- a/src/Application/Bookings/Commands/CreateBooking.cs
+++ b/src/Application/Bookings/Commands/CreateBooking.cs
@@ -1,7 +1,61 @@
 using MediatR;
 using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace AirlineBooking.Application.Bookings.Commands;
 
-public sealed record CreateBookingCommand(Guid FlightId, string FirstName, string LastName, string Email, int Seats, string IdempotencyKey) : IRequest<CreateBookingResult>;
+public sealed record CreateBookingCommand(
+    [Required]
+    Guid FlightId,
+
+    [Required]
+    [StringLength(100, MinimumLength = 1)]
+    string FirstName,
+
+    [Required]
+    [StringLength(100, MinimumLength = 1)]
+    string LastName,
+
+    [Required]
+    [EmailAddress]
+    string Email,
+
+    [Range(1, 9, ErrorMessage = "Seats must be between 1 and 9.")]
+    int Seats,
+
+    [Required]
+    [StringLength(100, MinimumLength = 3)]
+    string IdempotencyKey
+) : IRequest<CreateBookingResult>, IValidatableObject
+{
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (FlightId == Guid.Empty)
+        {
+            yield return new ValidationResult("Flight identifier cannot be empty.", new[] { nameof(FlightId) });
+        }
+
+        if (Seats <= 0)
+        {
+            yield return new ValidationResult("At least one seat must be booked.", new[] { nameof(Seats) });
+        }
+
+        if (string.IsNullOrWhiteSpace(FirstName))
+        {
+            yield return new ValidationResult("First name is required.", new[] { nameof(FirstName) });
+        }
+
+        if (string.IsNullOrWhiteSpace(LastName))
+        {
+            yield return new ValidationResult("Last name is required.", new[] { nameof(LastName) });
+        }
+
+        if (string.IsNullOrWhiteSpace(IdempotencyKey))
+        {
+            yield return new ValidationResult("Idempotency key is required.", new[] { nameof(IdempotencyKey) });
+        }
+    }
+}
+
 public sealed record CreateBookingResult(string Pnr, Guid BookingId, decimal Amount);

--- a/src/Application/Bookings/Queries/GetBookingByPnr.cs
+++ b/src/Application/Bookings/Queries/GetBookingByPnr.cs
@@ -1,7 +1,34 @@
 using MediatR;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 
 namespace AirlineBooking.Application.Bookings.Queries;
 
-public sealed record GetBookingByPnrQuery(string Pnr) : IRequest<BookingDto?>;
+public sealed record GetBookingByPnrQuery(
+    [Required]
+    [RegularExpression("^[A-Z0-9]{6}$", ErrorMessage = "PNR must be exactly 6 alphanumeric characters.")]
+    string Pnr
+) : IRequest<BookingDto?>, IValidatableObject
+{
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.IsNullOrWhiteSpace(Pnr))
+        {
+            yield return new ValidationResult("PNR cannot be empty.", new[] { nameof(Pnr) });
+            yield break;
+        }
+
+        if (Pnr.Length != 6)
+        {
+            yield return new ValidationResult("PNR must contain exactly six characters.", new[] { nameof(Pnr) });
+        }
+
+        if (Pnr.Length == 6 && Pnr.Any(ch => !char.IsLetterOrDigit(ch)))
+        {
+            yield return new ValidationResult("PNR must contain only letters and digits.", new[] { nameof(Pnr) });
+        }
+    }
+}
 
 public sealed record BookingDto(string Pnr, string Status, string FlightNumber, string Passenger, int Seats, decimal Amount);

--- a/src/Application/Flights/Commands/CreateFlight.cs
+++ b/src/Application/Flights/Commands/CreateFlight.cs
@@ -1,16 +1,75 @@
-﻿using MediatR;
+using MediatR;
 using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
+namespace AirlineBooking.Flights.Commands;
 
-namespace AirlineBooking.Flights.Commands
+public sealed record CreateFlightCommand(
+    [Required]
+    [RegularExpression("^[A-Z0-9-]{3,10}$", ErrorMessage = "Flight number must contain 3 to 10 alphanumeric characters or hyphen.")]
+    string FlightNumber,
+
+    [Required]
+    [StringLength(3, MinimumLength = 3, ErrorMessage = "From airport must be a 3 letter IATA code.")]
+    string FromAirport,
+
+    [Required]
+    [StringLength(3, MinimumLength = 3, ErrorMessage = "To airport must be a 3 letter IATA code.")]
+    string ToAirport,
+
+    [Required]
+    DateTimeOffset DepartureUtc,
+
+    [Required]
+    DateTimeOffset ArrivalUtc,
+
+    [Range(1, int.MaxValue, ErrorMessage = "Capacity must be at least 1.")]
+    int Capacity,
+
+    [Range(typeof(decimal), "0", "79228162514264337593543950335", ErrorMessage = "Base fare must be non-negative.")]
+    decimal BaseFare
+) : IRequest<Guid>, IValidatableObject
 {
-    public record CreateFlightCommand(
-        string FlightNumber,
-        string FromAirport,
-        string ToAirport,
-        DateTimeOffset DepartureUtc,
-        DateTimeOffset ArrivalUtc,
-        int Capacity,
-        decimal BaseFare
-    ) : IRequest<Guid>;
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.IsNullOrWhiteSpace(FlightNumber))
+        {
+            yield return new ValidationResult("Flight number is required.", new[] { nameof(FlightNumber) });
+        }
+
+        if (string.IsNullOrWhiteSpace(FromAirport))
+        {
+            yield return new ValidationResult("Origin airport is required.", new[] { nameof(FromAirport) });
+        }
+
+        if (string.IsNullOrWhiteSpace(ToAirport))
+        {
+            yield return new ValidationResult("Destination airport is required.", new[] { nameof(ToAirport) });
+        }
+
+        if (string.Equals(FromAirport, ToAirport, StringComparison.OrdinalIgnoreCase))
+        {
+            yield return new ValidationResult(
+                "Origin and destination airports must differ.",
+                new[] { nameof(FromAirport), nameof(ToAirport) });
+        }
+
+        if (ArrivalUtc <= DepartureUtc)
+        {
+            yield return new ValidationResult(
+                "Arrival time must be after departure time.",
+                new[] { nameof(ArrivalUtc), nameof(DepartureUtc) });
+        }
+
+        if (Capacity <= 0)
+        {
+            yield return new ValidationResult("Capacity must be greater than zero.", new[] { nameof(Capacity) });
+        }
+
+        if (BaseFare < 0)
+        {
+            yield return new ValidationResult("Base fare must be non-negative.", new[] { nameof(BaseFare) });
+        }
+    }
 }

--- a/src/Application/Flights/Queries/SearchFlights.cs
+++ b/src/Application/Flights/Queries/SearchFlights.cs
@@ -1,9 +1,40 @@
 using MediatR;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace AirlineBooking.Application.Flights.Queries;
 
-public sealed record SearchFlightsQuery(string From, string To, DateTime Date) : IRequest<IReadOnlyList<FlightDto>>;
+public sealed record SearchFlightsQuery(
+    [Required]
+    [StringLength(3, MinimumLength = 3, ErrorMessage = "From airport must be a 3 letter IATA code.")]
+    string From,
+
+    [Required]
+    [StringLength(3, MinimumLength = 3, ErrorMessage = "To airport must be a 3 letter IATA code.")]
+    string To,
+
+    [Required]
+    DateTime Date
+) : IRequest<IReadOnlyList<FlightDto>>, IValidatableObject
+{
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.IsNullOrWhiteSpace(From))
+        {
+            yield return new ValidationResult("Origin airport is required.", new[] { nameof(From) });
+        }
+
+        if (string.IsNullOrWhiteSpace(To))
+        {
+            yield return new ValidationResult("Destination airport is required.", new[] { nameof(To) });
+        }
+
+        if (string.Equals(From, To, StringComparison.OrdinalIgnoreCase))
+        {
+            yield return new ValidationResult("Origin and destination airports must differ.", new[] { nameof(From), nameof(To) });
+        }
+    }
+}
 
 public sealed record FlightDto(Guid Id, string FlightNumber, string From, string To, DateTimeOffset DepartureUtc, DateTimeOffset ArrivalUtc, decimal BaseFare);

--- a/src/Infrastructure/Services/FlightQueryService..cs
+++ b/src/Infrastructure/Services/FlightQueryService..cs
@@ -24,6 +24,9 @@ public sealed class FlightQueryService : IFlightQueryService
 
     public async Task<IReadOnlyList<FlightDto>> SearchAsync(string from, string to, DateTime date, CancellationToken ct)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(from);
+        ArgumentException.ThrowIfNullOrWhiteSpace(to);
+
         _logger.LogInformation("Searching flights in persistence from {From} to {To} on {Date}", from, to, date);
         var dateStart = new DateTimeOffset(date, TimeSpan.Zero);
         var dateEnd = dateStart.AddDays(1);


### PR DESCRIPTION
## Summary
- add explicit data-annotation validation to API controllers and requests
- decorate booking and flight commands/queries with data annotations and cross-field checks
- harden infrastructure flight search service against invalid inputs

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da11e7deec832984eaa4f40e35b407