### PR TITLE
Add Azure deployment assets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+**/bin
+**/obj
+**/out
+.git
+.gitignore
+Dockerfile
+README.md
+tests/
+*.db
+*.user
+*.suo
+node_modules
+infra/*.parameters.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+# copy solution and project files first to leverage layer caching
+COPY AirlineBooking.sln ./
+COPY src/Api/Api.csproj src/Api/
+COPY src/Application/Application.csproj src/Application/
+COPY src/Domain/Domain.csproj src/Domain/
+COPY src/Infrastructure/Infrastructure.csproj src/Infrastructure/
+COPY src/Workers/Workers.csproj src/Workers/
+
+RUN dotnet restore AirlineBooking.sln
+
+# copy the remaining source and publish the API
+COPY . .
+RUN dotnet publish src/Api/Api.csproj -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+
+COPY --from=build /app/publish ./
+
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "Api.dll"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@
 4. Run (F5). First run applies EF migrations and seeds sample flights.
 5. Open Swagger at `https://localhost:PORT/swagger`.
 
+## Deploy to Azure
+1. Review the infrastructure templates under [`infra/`](infra/) and update `infra/parameters.example.json` with unique resource names. Copy it to `infra/parameters.json` when ready.
+2. Deploy the infrastructure with the Azure CLI:
+   ```bash
+   az deployment group create \
+     --resource-group <your-resource-group> \
+     --template-file infra/main.bicep \
+     --parameters @infra/parameters.json
+   ```
+3. Build and push the container image using Docker:
+   ```bash
+   az acr login --name <registryName>
+   docker build -t <registryLoginServer>/airlinebooking-api:latest .
+   docker push <registryLoginServer>/airlinebooking-api:latest
+   ```
+4. (Optional) Configure the provided [Azure Pipeline](azure-pipelines.yml) to automate build, test, image publishing, infrastructure deployment and Web App updates.
+5. Set the required application settings or connection strings (e.g., `Database__UsePostgres`, `ConnectionStrings__Postgres`) either through pipeline variables or the Web App configuration UI.
+
 ### API samples
 - **Search flights**: `GET /api/flights/search?from=DEL&to=BOM&date=2025-09-26`  
 - **Create booking**:  

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,124 @@
+trigger:
+  branches:
+    include:
+      - main
+
+variables:
+  buildConfiguration: 'Release'
+  imageRepository: 'airlinebooking-api'
+  dockerfilePath: 'Dockerfile'
+  buildContext: '.'
+  tag: '$(Build.BuildId)'
+  # The following variables must be provided via pipeline variables or variable groups:
+  # dockerRegistryServiceConnection, azureSubscriptionServiceConnection,
+  # resourceGroupName, acrName, acrLoginServer, webAppName, appServicePlanName,
+  # environmentName, USE_POSTGRES (optional), POSTGRES_CONNECTION_STRING (optional)
+
+stages:
+  - stage: Build
+    displayName: Build and Test
+    jobs:
+      - job: Build
+        displayName: Restore, Build, Test and Publish
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: UseDotNet@2
+            displayName: 'Install .NET SDK'
+            inputs:
+              packageType: 'sdk'
+              version: '9.0.x'
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Restore solution'
+            inputs:
+              command: 'restore'
+              projects: 'AirlineBooking.sln'
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Build solution'
+            inputs:
+              command: 'build'
+              projects: 'AirlineBooking.sln'
+              arguments: '--configuration $(buildConfiguration)'
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Test solution'
+            inputs:
+              command: 'test'
+              projects: 'AirlineBooking.sln'
+              arguments: '--configuration $(buildConfiguration) --no-build'
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Publish API'
+            inputs:
+              command: 'publish'
+              publishWebProjects: false
+              projects: 'src/Api/Api.csproj'
+              arguments: '--configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)/publish'
+              zipAfterPublish: false
+
+          - publish: '$(Build.ArtifactStagingDirectory)/publish'
+            displayName: 'Publish API artifact'
+            artifact: 'api'
+
+          - task: Docker@2
+            displayName: 'Build and push image'
+            inputs:
+              command: 'buildAndPush'
+              repository: '$(imageRepository)'
+              dockerfile: '$(dockerfilePath)'
+              buildContext: '$(buildContext)'
+              containerRegistry: '$(dockerRegistryServiceConnection)'
+              tags: |
+                $(tag)
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish manifests'
+            inputs:
+              PathtoPublish: 'infra'
+              ArtifactName: 'infra'
+              publishLocation: 'Container'
+
+  - stage: Deploy
+    displayName: Deploy to Azure Web App
+    dependsOn: Build
+    condition: succeeded()
+    jobs:
+      - deployment: DeployWebApp
+        displayName: 'Deploy container image'
+        environment: 'production'
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - download: current
+                  artifact: infra
+
+                - task: AzureCLI@2
+                  displayName: 'Deploy infrastructure (Bicep)'
+                  inputs:
+                    azureSubscription: '$(azureSubscriptionServiceConnection)'
+                    scriptType: 'bash'
+                    scriptLocation: 'inlineScript'
+                    inlineScript: |
+                      az deployment group create \
+                        --resource-group $(resourceGroupName) \
+                        --template-file infra/main.bicep \
+                        --parameters \
+                          acrName=$(acrName) \
+                          webAppName=$(webAppName) \
+                          appServicePlanName=$(appServicePlanName) \
+                          containerImageName=$(imageRepository) \
+                          containerImageTag=$(tag) \
+                          usePostgres=${USE_POSTGRES:-true} \
+                          postgresConnectionString="${POSTGRES_CONNECTION_STRING:-}" \
+                          environmentName=$(environmentName)
+
+                - task: AzureWebApp@1
+                  displayName: 'Update Web App container'
+                  inputs:
+                    azureSubscription: '$(azureSubscriptionServiceConnection)'
+                    appType: 'webAppLinux'
+                    appName: '$(webAppName)'
+                    imageName: '$(acrLoginServer)/$(imageRepository):$(tag)'

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,59 @@
+# Azure deployment
+
+This folder contains infrastructure-as-code definitions and helper files to deploy the Airline Booking API to Azure.
+
+## Prerequisites
+
+* Azure CLI `2.53.0` or later.
+* An Azure subscription with permissions to create resource groups, App Service plans, Web Apps and Container Registries.
+* A PostgreSQL database (managed by Azure Database for PostgreSQL or another provider). Update the `postgresConnectionString` parameter to point at the database.
+* Docker installed locally if you plan to build and push images outside of Azure Pipelines.
+
+## Deploying the infrastructure
+
+1. Create (or choose) a resource group: `az group create --name airlinebooking-rg --location westus3`.
+2. Update the `infra/parameters.example.json` file with unique resource names and the PostgreSQL connection string, then rename it to `infra/parameters.json`.
+3. Deploy with the Azure CLI:
+
+   ```bash
+   az deployment group create \
+     --resource-group airlinebooking-rg \
+     --template-file infra/main.bicep \
+     --parameters @infra/parameters.json
+   ```
+
+The deployment will create:
+
+* A **Container Registry** where the API image is stored.
+* A **Linux App Service plan**.
+* A **Linux Web App** configured to run the container image.
+* A **managed identity** for the Web App with `AcrPull` permissions on the registry.
+
+After deployment you must push the container image to the registry (either manually or via the provided Azure Pipeline) and configure the Web App to use the new tag.
+
+## Azure Pipelines
+
+The repository includes an `azure-pipelines.yml` definition that:
+
+1. Restores, builds and tests the solution.
+2. Publishes the API artifact for traceability.
+3. Builds and pushes a container image to Azure Container Registry.
+4. Deploys the Bicep template to keep infrastructure in sync.
+5. Updates the Web App to run the freshly built container image.
+
+Configure the following pipeline variables or variable group secrets before running the pipeline:
+
+| Variable | Description |
+| --- | --- |
+| `dockerRegistryServiceConnection` | Service connection with permissions to push to the target ACR. |
+| `azureSubscriptionServiceConnection` | Service connection scoped to the resource group for deployments. |
+| `resourceGroupName` | Name of the resource group created earlier. |
+| `acrName` | Name of the Azure Container Registry. |
+| `acrLoginServer` | Login server of the registry (e.g. `myregistry.azurecr.io`). |
+| `webAppName` | Name of the Web App to deploy. |
+| `appServicePlanName` | Name of the App Service plan. |
+| `environmentName` | Tag used to identify the environment (e.g. `production`). |
+| `USE_POSTGRES` (optional) | Set to `false` to keep SQLite. |
+| `POSTGRES_CONNECTION_STRING` (optional) | Provide the PostgreSQL connection string for production. |
+
+> **Security note:** Store secrets (connection strings, database passwords) in secure variable groups or Azure Key Vault and reference them from the pipeline rather than committing them to source control.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,138 @@
+@description('The Azure region to deploy resources into.')
+param location string = resourceGroup().location
+
+@description('Environment name used for resource naming and tagging.')
+param environmentName string = 'prod'
+
+@description('Globally unique name for the Azure Container Registry (lowercase, 5-50 alphanumeric characters).')
+param acrName string
+
+@description('Name of the Linux App Service plan that will host the web app.')
+param appServicePlanName string = '${environmentName}-plan'
+
+@description('SKU for the App Service plan.')
+@allowed([
+  'B1'
+  'B2'
+  'B3'
+  'S1'
+  'S2'
+  'S3'
+])
+param appServicePlanSku string = 'B1'
+
+@description('Name of the Web App that will host the API container. Must be globally unique.')
+param webAppName string
+
+@description('Container image repository name (without registry login server).')
+param containerImageName string = 'airlinebooking-api'
+
+@description('Container image tag that should be deployed.')
+param containerImageTag string = 'latest'
+
+@description('Connection string for the PostgreSQL database used by the API. Leave empty to configure later.')
+@secure()
+param postgresConnectionString string = ''
+
+@description('When true the API will use PostgreSQL (recommended for Azure). Set to false to continue using SQLite.')
+param usePostgres bool = true
+
+var appSettings = [
+  {
+    name: 'WEBSITES_PORT'
+    value: '8080'
+  }
+  {
+    name: 'ASPNETCORE_ENVIRONMENT'
+    value: 'Production'
+  }
+  {
+    name: 'Database__UsePostgres'
+    value: string(usePostgres)
+  }
+]
+
+resource registry 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' = {
+  name: acrName
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    adminUserEnabled: false
+    policies: {
+      quarantinePolicy: {
+        status: 'disabled'
+      }
+    }
+  }
+}
+
+resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: appServicePlanName
+  location: location
+  sku: {
+    name: appServicePlanSku
+    tier: appServicePlanSku == 'B1' || appServicePlanSku == 'B2' || appServicePlanSku == 'B3' ? 'Basic' : 'Standard'
+  }
+  kind: 'linux'
+  properties: {
+    reserved: true
+  }
+  tags: {
+    Environment: environmentName
+  }
+}
+
+resource webApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: webAppName
+  location: location
+  kind: 'app,linux'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    httpsOnly: true
+    serverFarmId: plan.id
+    siteConfig: {
+      linuxFxVersion: 'DOCKER|${registry.properties.loginServer}/${containerImageName}:${containerImageTag}'
+      appSettings: appSettings
+      alwaysOn: true
+    }
+    clientAffinityEnabled: false
+  }
+  tags: {
+    Environment: environmentName
+  }
+}
+
+@description('Assign the web app managed identity permissions to pull from the container registry.')
+resource webAppAcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: registry
+  name: guid(webApp.identity.principalId, registry.id, 'acrpull')
+  properties: {
+    principalId: webApp.identity.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+  }
+  dependsOn: [
+    webApp
+  ]
+}
+
+resource postgresConnection 'Microsoft.Web/sites/config@2023-12-01' = if (!empty(postgresConnectionString)) {
+  parent: webApp
+  name: 'connectionstrings'
+  properties: {
+    Postgres: {
+      value: postgresConnectionString
+      type: 'PostgreSQL'
+    }
+  }
+}
+
+output containerRegistryLoginServer string = registry.properties.loginServer
+output appServicePrincipalId string = webApp.identity.principalId

--- a/infra/parameters.example.json
+++ b/infra/parameters.example.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "prod"
+    },
+    "acrName": {
+      "value": "<yourUniqueRegistryName>"
+    },
+    "appServicePlanName": {
+      "value": "prod-plan"
+    },
+    "appServicePlanSku": {
+      "value": "B1"
+    },
+    "webAppName": {
+      "value": "<yourUniqueWebAppName>"
+    },
+    "containerImageName": {
+      "value": "airlinebooking-api"
+    },
+    "containerImageTag": {
+      "value": "latest"
+    },
+    "postgresConnectionString": {
+      "value": "Host=<server>.postgres.database.azure.com;Port=5432;Database=airlinebooking;Username=<user>;Password=<password>;Ssl Mode=Require"
+    },
+    "usePostgres": {
+      "value": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add production-ready Dockerfile and dockerignore to containerize the API
- provide infrastructure as code for Azure App Service and Container Registry
- add Azure Pipelines workflow and documentation for end-to-end deployment guidance

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daaa1847948329bad76323fdc245be