### PR TITLE
Fix flight search date handling

### DIFF
--- a/src/Api/Controllers/FlightsController.cs
+++ b/src/Api/Controllers/FlightsController.cs
@@ -2,6 +2,7 @@
 using AirlineBooking.Flights.Commands;
 using AirlineBooking.Infrastructure.Persistence;
 using MediatR;
+using System;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -22,7 +23,7 @@ public class FlightsController : ControllerBase
     }
 
     [HttpGet("search")]
-    public async Task<IActionResult> SearchFlights([FromQuery] string from, [FromQuery] string to, [FromQuery] DateTime date)
+    public async Task<IActionResult> SearchFlights([FromQuery] string from, [FromQuery] string to, [FromQuery] DateOnly date)
     {
         _logger.LogInformation("Searching flights from {From} to {To} on {Date}", from, to, date);
         var result = await _mediator.Send(new SearchFlightsQuery(from, to, date));

--- a/src/Application/Common/Interfaces/IFlightQueryService.cs
+++ b/src/Application/Common/Interfaces/IFlightQueryService.cs
@@ -8,5 +8,5 @@ namespace AirlineBooking.Application.Common.Interfaces;
 
 public interface IFlightQueryService
 {
-    Task<IReadOnlyList<FlightDto>> SearchAsync(string from, string to, DateTime date, CancellationToken ct);
+    Task<IReadOnlyList<FlightDto>> SearchAsync(string from, string to, DateOnly date, CancellationToken ct);
 }

--- a/src/Application/Flights/Queries/SearchFlights.cs
+++ b/src/Application/Flights/Queries/SearchFlights.cs
@@ -4,6 +4,6 @@ using System.Collections.Generic;
 
 namespace AirlineBooking.Application.Flights.Queries;
 
-public sealed record SearchFlightsQuery(string From, string To, DateTime Date) : IRequest<IReadOnlyList<FlightDto>>;
+public sealed record SearchFlightsQuery(string From, string To, DateOnly Date) : IRequest<IReadOnlyList<FlightDto>>;
 
 public sealed record FlightDto(Guid Id, string FlightNumber, string From, string To, DateTimeOffset DepartureUtc, DateTimeOffset ArrivalUtc, decimal BaseFare);

--- a/src/Infrastructure/Services/FlightQueryService..cs
+++ b/src/Infrastructure/Services/FlightQueryService..cs
@@ -22,10 +22,10 @@ public sealed class FlightQueryService : IFlightQueryService
         _logger = logger;
     }
 
-    public async Task<IReadOnlyList<FlightDto>> SearchAsync(string from, string to, DateTime date, CancellationToken ct)
+    public async Task<IReadOnlyList<FlightDto>> SearchAsync(string from, string to, DateOnly date, CancellationToken ct)
     {
         _logger.LogInformation("Searching flights in persistence from {From} to {To} on {Date}", from, to, date);
-        var dateStart = new DateTimeOffset(date, TimeSpan.Zero);
+        var dateStart = new DateTimeOffset(date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
         var dateEnd = dateStart.AddDays(1);
 
         var fromUpper = from.Trim().ToUpperInvariant();


### PR DESCRIPTION
## Summary
- update the flight search API contract to take a DateOnly for the travel date
- convert the requested search date into a UTC day range when querying flights

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db5c97d688832982e52a9f79097947